### PR TITLE
Support Zig 0.14: Make the package name a bare Zig-identifier.

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "sdl3-prebuilt-x86_64-windows-gnu",
+    .name = .sdl3_prebuilt_x86_64_windows_gnu,
     .version = "0.1.0",
     .paths = .{
         "build.zig.zon",


### PR DESCRIPTION
See https://ziglang.org/download/0.14.0/release-notes.html#Build-System and zig-gamedev/zsdl/issues/16.

Package names must now be bare Zig-identifiers with zig 0.14.0. It doesn't seem like `.@"identifier name"` syntax works (I suppose that's what they mean by _bare_ identifier). So, I propose replacing dashes with underscores in the package name.

After this change and couple of other similar changes I was able to build [zig-gamedev/zsdl](https://github.com/zig-gamedev/zsdl) with zig 0.14 on windows.